### PR TITLE
Us11 selecionar tipo de documento financeiro

### DIFF
--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -2,7 +2,7 @@
 .data-table {
     width: 100%;
     border-collapse: separate; /* Mude para 'separate' para ativar o border-spacing */
-    border-spacing: 0.4rem;
+    border-spacing: 0.313rem;
     margin-top: 20px;
 }
 .data-table th{
@@ -11,12 +11,16 @@
     font-size: 1.5rem;
     font-family: inter;
     font-size: 1.25rem;
+    color: black;
 }
 .data-table td {
-    padding: 1.5rem 1rem;
+    padding: 0.938rem 1rem;
     text-align: left;
     background-color: #EAE3D7;
     border-radius: 10px;
+    font-family: inter;
+    font-size: 1rem;
+    
 }
 
 /*botão de upload */
@@ -39,6 +43,7 @@
 .titulo-extrato{
     font-size: 2rem;
     padding-top: 2rem;
+    color: #341F14;
     font-family: Noto Sans;
     font-weight: bold;
 }

--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -1,0 +1,77 @@
+/* tabela */
+.data-table {
+    width: 100%;
+    border-collapse: separate; /* Mude para 'separate' para ativar o border-spacing */
+    border-spacing: 0.313rem;
+    margin-top: 20px;
+}
+.data-table th{
+    text-align: left;
+    padding-left: 1rem;
+    font-size: 1.5rem;
+    font-family: inter;
+    font-size: 1.25rem;
+    color: black;
+}
+.data-table td {
+    padding: 0.938rem 1rem;
+    text-align: left;
+    background-color: #EAE3D7;
+    border-radius: 10px;
+    font-family: inter;
+    font-size: 1rem;
+    
+}
+
+/*botão de download CSV */
+button.export-button{
+    display: inline-block;
+    padding: 0.5rem;
+    display: medium;
+    text-align: center;
+    width: 420px;
+    font-family: Noto Sans;
+    font-size: 16px;
+    color: #AE883C !important;
+    background-color: #EAE3D7; /* Cor de fundo */
+    border: 0.15rem solid #AE883C; /* Cor da borda */
+    border-radius: 5px; /* Borda arredondada */
+    cursor: pointer; /* Deixa o cursor como uma mãozinha */
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
+    margin-top: 2rem;
+}
+
+/* container principal */
+.data-import {
+    padding-left: 7.5rem;
+    max-width: 65rem;
+}
+
+.titulo-extrato{
+    font-size: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 5rem;
+    color: #341F14;
+    font-family: Noto Sans;
+    font-weight: bold;
+}
+
+.upload-arquivo label {
+    display: inline-block;
+    padding: 0.5rem;
+    display: medium;
+    text-align: center;
+    width: 420px;
+    font-family: Noto Sans;
+    font-size: 16px;
+    color: #AE883C !important;
+    background-color: #EAE3D7; /* Cor de fundo */
+    border: 0.15rem solid #AE883C; /* Cor da borda */
+    border-radius: 5px; /* Borda arredondada */
+    cursor: pointer; /* Deixa o cursor como uma mãozinha */
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.upload-arquivo #file-upload {
+    display: none; /* Oculta o input de upload padrão */
+}

--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -23,38 +23,55 @@
     
 }
 
-/*botão de upload */
-.data-import input[type="file"] {
-    padding: 0.938rem 1rem;
-    text-align: left;
-    background-color: #EAE3D7;
-    border-radius: 10px;
-    font-family: inter;
-    font-size: 1rem;
-}
-
 /*botão de download CSV */
 button.export-button{
-    padding: 0.938rem 1rem;
-    text-align: left;
-    background-color: #EAE3D7;
-    border-radius: 10px;
-    font-family: inter;
-    font-size: 1rem;
-    margin-left: 1rem;
+    display: inline-block;
+    padding: 0.5rem;
+    display: medium;
+    text-align: center;
+    width: 420px;
+    font-family: Noto Sans;
+    font-size: 16px;
+    color: #AE883C !important;
+    background-color: #EAE3D7; /* Cor de fundo */
+    border: 0.15rem solid #AE883C; /* Cor da borda */
+    border-radius: 5px; /* Borda arredondada */
+    cursor: pointer; /* Deixa o cursor como uma mãozinha */
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
+    margin-top: 2rem;
 }
 
 /* container principal */
 .data-import {
     padding-left: 7.5rem;
-    max-width: 800px;
-    font-family: Arial, sans-serif;
+    max-width: 65rem;
 }
 
 .titulo-extrato{
     font-size: 2rem;
     padding-top: 2rem;
+    padding-bottom: 5rem;
     color: #341F14;
     font-family: Noto Sans;
     font-weight: bold;
+}
+
+.upload-arquivo label {
+    display: inline-block;
+    padding: 0.5rem;
+    display: medium;
+    text-align: center;
+    width: 420px;
+    font-family: Noto Sans;
+    font-size: 16px;
+    color: #AE883C !important;
+    background-color: #EAE3D7; /* Cor de fundo */
+    border: 0.15rem solid #AE883C; /* Cor da borda */
+    border-radius: 5px; /* Borda arredondada */
+    cursor: pointer; /* Deixa o cursor como uma mãozinha */
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.upload-arquivo #file-upload {
+    display: none; /* Oculta o input de upload padrão */
 }

--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -23,22 +23,27 @@
     
 }
 
-/*botão de download CSV */
-button.export-button{
-    display: inline-block;
-    padding: 0.5rem;
-    display: medium;
-    text-align: center;
-    width: 420px;
-    font-family: Noto Sans;
-    font-size: 16px;
-    color: #AE883C !important;
-    background-color: #EAE3D7; /* Cor de fundo */
-    border: 0.15rem solid #AE883C; /* Cor da borda */
-    border-radius: 5px; /* Borda arredondada */
-    cursor: pointer; /* Deixa o cursor como uma mãozinha */
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
-    margin-top: 2rem;
+.data-table td .text-input{
+    padding: 0.5rem 0.5rem;
+    text-align: left;
+    background-color: #EAE3D7;
+    font-family: inter;
+    font-size: 1rem;
+    border: none;
+    width: calc(100% - 2rem);
+}
+
+.data-table td select{
+    width: 100%;
+    height: 100%;
+    border: none;
+    font: inherit;
+    color: inherit;
+    background: inherit;
+}
+
+.data-table td input.text-input:focus {
+    outline: none;
 }
 
 /* container principal */
@@ -74,4 +79,16 @@ button.export-button{
 
 .upload-arquivo #file-upload {
     display: none; /* Oculta o input de upload padrão */
+}
+
+.botoes{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.botoes div{
+    width: 420px;
+    padding: 0.5rem;
+    font-size: 16px;
 }

--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -1,38 +1,26 @@
 /* tabela */
 .data-table {
     width: 100%;
-    border-collapse: collapse;
+    border-collapse: separate; /* Mude para 'separate' para ativar o border-spacing */
+    border-spacing: 0.4rem;
     margin-top: 20px;
 }
-
-.data-table th,
-.data-table td {
-    padding: 12px 15px;
+.data-table th{
     text-align: left;
-    border: 1px solid #ddd;
+    padding-left: 1rem;
+    font-size: 1.5rem;
+    font-family: inter;
+    font-size: 1.25rem;
 }
-
-.data-table th {
-    color: black;
-}
-
-.data-table tr:nth-child(even) {
+.data-table td {
+    padding: 1.5rem 1rem;
+    text-align: left;
     background-color: #EAE3D7;
-}
-
-.data-table tr:hover {
-    background-color: #EAE3D7;
-}
-
-/* mensagem quando não houver dados */
-.data-table td[colspan="3"] {
-    text-align: center;
-    font-style: italic;
-    color: #888;
+    border-radius: 10px;
 }
 
 /*botão de upload */
-input[type="file"] {
+.data-import input[type="file"] {
     margin: 20px 0;
     padding: 10px;
     font-size: 16px;
@@ -41,21 +29,16 @@ input[type="file"] {
     cursor: pointer;
 }
 
-input[type="file"]:hover {
-    background-color: #f1f1f1;
-    color: #AE883C;
-}
-
-/* Estilizando o título */
-h1 {
-    color: #333;
-    font-size: 24px;
-    text-align: center;
-}
-
 /* container principal */
 .data-import {
+    padding-left: 7.5rem;
     max-width: 800px;
-    margin: 0 auto;
     font-family: Arial, sans-serif;
+}
+
+.titulo-extrato{
+    font-size: 2rem;
+    padding-top: 2rem;
+    font-family: Noto Sans;
+    font-weight: bold;
 }

--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -24,9 +24,6 @@
 }
 .css-mck6no-MuiInputBase-root-MuiFilledInput-root-MuiSelect-root{
     min-width: 200px;
-}
-
-.css-2vnt94-MuiFormControl-root{
     margin: 0 !important;
 }
 

--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -1,0 +1,61 @@
+/* tabela */
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+.data-table th,
+.data-table td {
+    padding: 12px 15px;
+    text-align: left;
+    border: 1px solid #ddd;
+}
+
+.data-table th {
+    color: black;
+}
+
+.data-table tr:nth-child(even) {
+    background-color: #EAE3D7;
+}
+
+.data-table tr:hover {
+    background-color: #EAE3D7;
+}
+
+/* mensagem quando não houver dados */
+.data-table td[colspan="3"] {
+    text-align: center;
+    font-style: italic;
+    color: #888;
+}
+
+/*botão de upload */
+input[type="file"] {
+    margin: 20px 0;
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+input[type="file"]:hover {
+    background-color: #f1f1f1;
+    color: #AE883C;
+}
+
+/* Estilizando o título */
+h1 {
+    color: #333;
+    font-size: 24px;
+    text-align: center;
+}
+
+/* container principal */
+.data-import {
+    max-width: 800px;
+    margin: 0 auto;
+    font-family: Arial, sans-serif;
+}

--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -25,12 +25,23 @@
 
 /*botão de upload */
 .data-import input[type="file"] {
-    margin: 20px 0;
-    padding: 10px;
-    font-size: 16px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    cursor: pointer;
+    padding: 0.938rem 1rem;
+    text-align: left;
+    background-color: #EAE3D7;
+    border-radius: 10px;
+    font-family: inter;
+    font-size: 1rem;
+}
+
+/*botão de download CSV */
+button.export-button{
+    padding: 0.938rem 1rem;
+    text-align: left;
+    background-color: #EAE3D7;
+    border-radius: 10px;
+    font-family: inter;
+    font-size: 1rem;
+    margin-left: 1rem;
 }
 
 /* container principal */

--- a/src/Pages/Protected/DataImport/index.css
+++ b/src/Pages/Protected/DataImport/index.css
@@ -22,6 +22,13 @@
     font-size: 1rem;
     
 }
+.css-mck6no-MuiInputBase-root-MuiFilledInput-root-MuiSelect-root{
+    min-width: 200px;
+}
+
+.css-2vnt94-MuiFormControl-root{
+    margin: 0 !important;
+}
 
 .data-table td .text-input{
     padding: 0.5rem 0.5rem;

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -17,9 +17,12 @@ const DataImport = () => {
 
             try {
                 const parsedTransactions = [];
-                const transactionRegex = /<STMTTRN>[\s\S]*?<DTPOSTED>([\d]+)[\s\S]*?<TRNAMT>([-\d.]+)[\s\S]*?(?:<NAME>(.*?)<\/NAME>[\s\S]*?)?(?:<MEMO>(.*?)<\/MEMO>)?/g;
-                let match;
+                const transactionRegex = /<STMTTRN>[\s\S]*?<DTPOSTED>([\d]+)[\s\S]*?<TRNAMT>([-\d.]+)[\s\S]*?(?:<NAME>(.*?)<\/NAME>)?[\s\S]*?(?:<MEMO>(.*?)<\/MEMO>)?/g;
+                const accountInfoRegex = /<BANKACCTFROM>[\s\S]*?<BANKID>(.*?)<\/BANKID>[\s\S]*?<ACCTID>(.*?)<\/ACCTID>[\s\S]*?<ACCTTYPE>(.*?)<\/ACCTTYPE>/;
+                const includeTransactionRegex = /<INCTRAN>[\s\S]*?<INCLUDE>(.*?)<\/INCLUDE>/;
 
+                // Captura informações de transações
+                let match;
                 while ((match = transactionRegex.exec(content)) !== null) {
                     const rawDate = match[1];
                     const formattedDate = formatDate(rawDate);
@@ -30,6 +33,21 @@ const DataImport = () => {
                         name: match[3] || "N/A", // Valor padrão se NAME não existir
                         memo: match[4] || "N/A", // Valor padrão se MEMO não existir
                     });
+                }
+
+                // Captura informações da conta bancária (se disponível)
+                const accountMatch = accountInfoRegex.exec(content);
+                if (accountMatch) {
+                    console.log("Informações da conta bancária:");
+                    console.log("Banco ID:", accountMatch[1]);
+                    console.log("Conta ID:", accountMatch[2]);
+                    console.log("Tipo de conta:", accountMatch[3]);
+                }
+
+                // Verifica se as transações devem ser incluídas (se disponível)
+                const includeMatch = includeTransactionRegex.exec(content);
+                if (includeMatch) {
+                    console.log("Incluir transações:", includeMatch[1] === "Y" ? "Sim" : "Não");
                 }
 
                 console.log("Transações extraídas:", parsedTransactions);
@@ -53,11 +71,44 @@ const DataImport = () => {
         return `${day}/${month}/${year}`;
     };
 
+    const exportToCSV = () => {
+        if (transactions.length === 0) {
+            alert("Nenhuma transação para exportar.");
+            return;
+        }
+
+        const headers = ["Descrição", "Valor (R$)", "Data", "Nome"];
+        const rows = transactions.map((transaction) => [
+            transaction.memo,
+            transaction.amount.toFixed(2),
+            transaction.date,
+            transaction.name,
+        ]);
+
+        const csvContent = [headers, ...rows]
+            .map((row) => row.join(","))
+            .join("\n");
+
+        const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+        const url = URL.createObjectURL(blob);
+
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = "transacoes.csv";
+        link.click();
+
+        URL.revokeObjectURL(url);
+    };
 
     return (
         <div className="data-import">
-            <div className = "titulo-extrato">Importar Extrato Bancário</div>
-            <input type="file" accept=".ofx" onChange={handleFileUpload}/>
+            <div className="titulo-extrato">Importar Extrato Bancário</div>
+            <input type="file" accept=".ofx" onChange={handleFileUpload} />
+            {transactions.length > 0 && (
+                <button className="export-button" onClick={exportToCSV}>
+                    Exportar para CSV
+                </button>
+            )}
             <table className="data-table">
                 <thead>
                 <tr>
@@ -76,7 +127,7 @@ const DataImport = () => {
                     transactions.map((transaction, index) => (
                         <tr key={index}>
                             <td>{transaction.memo}</td>
-                            <td>{transaction.amount.toFixed(2)}</td> 
+                            <td>{transaction.amount.toFixed(2)}</td>
                             <td>{transaction.date}</td>
                             <td>{transaction.name}</td>
                         </tr>
@@ -84,6 +135,7 @@ const DataImport = () => {
                 )}
                 </tbody>
             </table>
+
         </div>
     );
 };

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -91,35 +91,6 @@ const DataImport = () => {
         return `${day}/${month}/${year}`;
     };
 
-    const exportToCSV = () => {
-        if (transactions.length === 0) {
-            alert("Nenhuma transação para exportar.");
-            return;
-        }
-
-        const headers = ["Descrição", "Valor (R$)", "Data", "Nome", "Fixo"];
-        const rows = transactions.map((transaction) => [
-            transaction.memo,
-            transaction.amount.toFixed(2),
-            transaction.date,
-            transaction.name,
-            transaction.isFixed ? "Sim" : "Não", // adiciona a coluna fixo ao csv
-        ]);
-
-        const csvContent = [headers, ...rows]
-            .map((row) => row.join(","))
-            .join("\n");
-
-        const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-        const url = URL.createObjectURL(blob);
-
-        const link = document.createElement("a");
-        link.href = url;
-        link.download = "transacoes.csv";
-        link.click();
-
-        URL.revokeObjectURL(url);
-    };
     function formatDateBanco(str) {
         let date = new Date(str);
         let day = String(date.getDate()).padStart(2, '0');
@@ -143,11 +114,12 @@ const DataImport = () => {
                     <label className="input-ofx" for="file-upload">SELECIONE UM ARQUIVO</label>
                     <input id="file-upload" type="file" accept=".ofx" onChange={handleFileUpload} />
                 </div>
-                {transactions.length > 0 && (
-                    <button className="export-button" onClick={exportToCSV}>
-                        Exportar para CSV
-                    </button>
-                )}
+                <div className="save-button">
+                    <PrimaryButton 
+                        text="SALVAR"
+                        //onClick={handleSave}...
+                    />
+                </div>
             </div>
             <table className="data-table">
                 <thead>

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -23,14 +23,14 @@ const DataImport = () => {
             const fetchedTransactions = [];
            
             for (let i = 0; i < data.length; i++) {
-                if(data[i].tipoDocumento == ""){
+                if(data[i].tipoDocumento){ /*alterar*/
                     fetchedTransactions.push({
                         date: formatDateBanco(data[i].datadePagamento),
                         amount: data[i].valorBruto,
                         name: data[i].tipoDocumento,
                         memo: data[i].descricao,
                         isFixed: false,
-                        tipoDocumento: data[i].tipoDocumento || "",
+                        tipoDocumento: data[i].tipoDocumento,
                     });
                 }
             }
@@ -164,8 +164,8 @@ const DataImport = () => {
                             <td>
                                 <FieldSelect
                                   label= ""
-                                  onChange={(option) => handleChangeTipoDocumento(index, option)}
-                                  value={transaction.tipoDocumento || ""}
+                                  onChange={(e) => handleChangeTipoDocumento(index, e.target.value)}           
+                                  value={transaction.tipoDocumento}
                                   options={[
                                     "",
                                     "AÇÃO JUDICIAL",

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -146,7 +146,7 @@ const DataImport = () => {
 
         for (let i = 0; i < updatedTransactions.length; i++) {
             let updatedData;
-            if(updatedTransactions[i].amount < 0){
+            if(updatedTransactions[i].amount > 0){
                 updatedData = {
                     contaDestino: "Sindicato",
                     nomeDestino: "Conta BRB",
@@ -181,7 +181,7 @@ const DataImport = () => {
                     } else {
                         await updateFinancialMovementsById(updatedTransactions[i].id, updatedData);
                     }
-                    if(updatedData.tipoDocumento !== ""){
+                    if(updatedData.tipoDocumento !== " "){
                         updatedTransactions.splice(i, 1);
                         i--;
                     }

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -56,15 +56,15 @@ const DataImport = () => {
 
     return (
         <div className="data-import">
-            <h1>Importar OFX</h1>
+            <div className = "titulo-extrato">Importar Extrato Bancário</div>
             <input type="file" accept=".ofx" onChange={handleFileUpload}/>
             <table className="data-table">
                 <thead>
                 <tr>
-                    <th>Data</th>
                     <th>Descrição</th>
+                    <th>Valor (R$)</th>
+                    <th>Data</th>
                     <th>Nome</th>
-                    <th>Valor</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -75,10 +75,10 @@ const DataImport = () => {
                 ) : (
                     transactions.map((transaction, index) => (
                         <tr key={index}>
-                            <td>{transaction.date}</td>
                             <td>{transaction.memo}</td>
+                            <td>{transaction.amount.toFixed(2)}</td> 
+                            <td>{transaction.date}</td>
                             <td>{transaction.name}</td>
-                            <td>{transaction.amount.toFixed(2)}</td>
                         </tr>
                     ))
                 )}

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -94,12 +94,17 @@ const DataImport = () => {
     return (
         <div className="data-import">
             <div className="titulo-extrato">Importar Extrato Bancário</div>
-            <input type="file" accept=".ofx" onChange={handleFileUpload} />
-            {transactions.length > 0 && (
-                <button className="export-button" onClick={exportToCSV}>
-                    Exportar para CSV
-                </button>
-            )}
+            <div className="botoes">
+                <div className="upload-arquivo">
+                    <label className="input-ofx" for="file-upload">SELECIONE UM ARQUIVO</label>
+                    <input id="file-upload" type="file" accept=".ofx" onChange={handleFileUpload} />
+                </div>
+                {transactions.length > 0 && (
+                    <button className="export-button" onClick={exportToCSV}>
+                        Exportar para CSV
+                    </button>
+                )}
+            </div>
             <table className="data-table">
                 <thead>
                 <tr>

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -106,6 +106,22 @@ const DataImport = () => {
         setTransactions(newTransactions);
     };
 
+    const handleDescriptionChange = (index, value) => {
+        setTransactions((prevTransactions) => {
+            const newTransactions = [...prevTransactions];
+            newTransactions[index].memo = value;
+            return newTransactions;
+        });
+    };
+    
+    const handleChangeTipoDocumento = (index, option) => {
+        setTransactions((prevTransactions) => {
+            const newTransactions = [...prevTransactions];
+            newTransactions[index].tipoDocumento = option;
+            return newTransactions;
+        });
+      };
+
     return (
         <div className="data-import">
             <div className="titulo-extrato">Importar Extrato Bancário</div>
@@ -127,7 +143,7 @@ const DataImport = () => {
                     <th>Descrição</th>
                     <th>Valor (R$)</th>
                     <th>Data</th>
-                    <th>Nome</th>
+                    <th>Tipo de documento</th>
                     <th>Fixo</th>
                 </tr>
                 </thead>
@@ -139,10 +155,16 @@ const DataImport = () => {
                 ) : (
                     transactions.map((transaction, index) => (
                         <tr key={index}>
-                            <td>{transaction.memo}</td>
+                            <td>{<input className="text-input" type="text" value={transaction.memo} onChange={(e) => handleDescriptionChange(index, e.target.value)}/>}</td>
                             <td>{transaction.amount.toFixed(2)}</td>
                             <td>{transaction.date}</td>
-                            <td>{transaction.name}</td>
+                            <td><select
+                                    className="tipo-documento"
+                                    onChange={(e) => handleChangeTipoDocumento(index, e.target.value)}
+                                    >
+                                        <option></option>
+                                    </select>
+                            </td>
                             <td>
                                 <input
                                     type="checkbox"

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { APIBank } from "../../../Services/BaseService";
 import PrimaryButton from "../../../Components/PrimaryButton";
+import FieldSelect from "../../../Components/FieldSelect";
 import "./index.css";
 
 const DataImport = () => {
     const [transactions, setTransactions] = useState([]);
 
     const storagedUser = JSON.parse(localStorage.getItem("@App:user"));
+    const [tipoDocumento, setTipoDocumento] = useState("");
 
     useEffect(() => {
         const fetchTransactions = async () => {
@@ -28,6 +30,7 @@ const DataImport = () => {
                         name: data[i].tipoDocumento,
                         memo: data[i].descricao,
                         isFixed: false,
+                        tipoDocumento: data[i].tipoDocumento || "",
                     });
                 }
             }
@@ -133,7 +136,7 @@ const DataImport = () => {
                 <div className="save-button">
                     <PrimaryButton 
                         text="SALVAR"
-                        //onClick={handleSave}...
+                        onClick={handleChangeTipoDocumento}/*alterar quando a função handleSave tiver funcionando*/
                     />
                 </div>
             </div>
@@ -158,12 +161,57 @@ const DataImport = () => {
                             <td>{<input className="text-input" type="text" value={transaction.memo} onChange={(e) => handleDescriptionChange(index, e.target.value)}/>}</td>
                             <td>{transaction.amount.toFixed(2)}</td>
                             <td>{transaction.date}</td>
-                            <td><select
-                                    className="tipo-documento"
-                                    onChange={(e) => handleChangeTipoDocumento(index, e.target.value)}
-                                    >
-                                        <option></option>
-                                    </select>
+                            <td>
+                                <FieldSelect
+                                  label= ""
+                                  onChange={(option) => handleChangeTipoDocumento(index, option)}
+                                  value={transaction.tipoDocumento || ""}
+                                  options={[
+                                    "",
+                                    "AÇÃO JUDICIAL",
+                                    "ACORDO EXTRAJUDICIAL",
+                                    "ADVOGADO",
+                                    "ALUGUEL",
+                                    "APLICAÇÃO FINANCEIRA",
+                                    "ASSEMBLEIA",
+                                    "ASSESSORIA COMUNICAÇÃO",
+                                    "CARTÓRIO",
+                                    "CELULAR",
+                                    "COMBUSTÍVEL",
+                                    "CONDOMÍNO",
+                                    "CONTABILIDADE",
+                                    "CONVÊNIO",
+                                    "CUSTAS JUDICIAIS",
+                                    "DARF",
+                                    "DAR-GDF",
+                                    "DIVERSOS",
+                                    "DOAÇÕES",
+                                    "DPVAT",
+                                    "ENERGIA",
+                                    "ESTÁGIO",
+                                    "EVENTOS",
+                                    "EXPEDIENTE",
+                                    "FGTS",
+                                    "FIXO/INTERNET",
+                                    "FUNCIONÁRIO",
+                                    "GPS (INSS)",
+                                    "IMÓVEL - SEDE SINDPEN",
+                                    "INDENIZAÇÃO",
+                                    "IPTU",
+                                    "IPVA",
+                                    "LAZER",
+                                    "LICENCIAMENTO",
+                                    "MULTA",
+                                    "PAPELARIA",
+                                    "PATROCÍNIO",
+                                    "REEMBOLSO",
+                                    "RESCISÃO CONTRATO TRAB.",
+                                    "RESTAURANTE",
+                                    "SEGURO VIDA",
+                                    "TARIFAS BANCÁRIAS",
+                                    "PUBLICIDADE",
+                                  ]}
+                                />
                             </td>
                             <td>
                                 <input

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import "./index.css";
+
+const DataImport = () => {
+    const [transactions, setTransactions] = useState([]);
+
+    const handleFileUpload = (event) => {
+        const file = event.target.files[0];
+        if (!file) {
+            console.error("Nenhum arquivo selecionado.");
+            return;
+        }
+
+        console.log("Arquivo selecionado:", file);
+
+        const reader = new FileReader();
+        reader.onload = () => {
+            const content = reader.result;
+
+            console.log("Conteúdo do arquivo:", content);
+
+            try {
+                const parsedTransactions = [];
+                const transactionRegex = /<STMTTRN>[\s\S]*?<TRNTYPE>(.*?)<\/TRNTYPE>[\s\S]*?<DTPOSTED>([\d]+)<\/DTPOSTED>[\s\S]*?<TRNAMT>([-\d.]+)<\/TRNAMT>[\s\S]*?<NAME>(.*?)<\/NAME>[\s\S]*?<MEMO>(.*?)<\/MEMO>/g;
+                let match;
+
+                while ((match = transactionRegex.exec(content)) !== null) {
+                    const rawDate = match[2];
+                    const formattedDate = formatDate(rawDate);
+
+                    parsedTransactions.push({
+                        trnType: match[1],
+                        date: formattedDate,
+                        amount: parseFloat(match[3]),
+                        name: match[4],
+                        memo: match[5],
+                    });
+                }
+
+                console.log("Transações extraídas:", parsedTransactions);
+                setTransactions(parsedTransactions);
+            } catch (error) {
+                console.error("Erro ao processar o arquivo:", error);
+            }
+        };
+
+        reader.onerror = () => {
+            console.error("Erro ao ler o arquivo.");
+        };
+
+        reader.readAsText(file);
+    };
+
+    const formatDate = (rawDate) => {
+        const year = rawDate.substring(0, 4);
+        const month = rawDate.substring(4, 6);
+        const day = rawDate.substring(6, 8);
+        return `${day}/${month}/${year}`;
+    };
+
+    return (
+        <div className="data-import">
+            <h1>Importar OFX</h1>
+            <input type="file" accept=".ofx" onChange={handleFileUpload} />
+            <table className="data-table">
+                <thead>
+                <tr>
+                    <th>Tipo</th>
+                    <th>Data</th>
+                    <th>Valor</th>
+                    <th>Nome</th>
+                    <th>Descrição</th>
+                </tr>
+                </thead>
+                <tbody>
+                {transactions.length === 0 ? (
+                    <tr>
+                        <td colSpan="5">Nenhuma transação encontrada.</td>
+                    </tr>
+                ) : (
+                    transactions.map((transaction, index) => (
+                        <tr key={index}>
+                            <td>{transaction.trnType}</td>
+                            <td>{transaction.date}</td>
+                            <td>{transaction.amount.toFixed(2)}</td>
+                            <td>{transaction.name}</td>
+                            <td>{transaction.memo}</td>
+                        </tr>
+                    ))
+                )}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default DataImport;

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -11,29 +11,24 @@ const DataImport = () => {
             return;
         }
 
-        console.log("Arquivo selecionado:", file);
-
         const reader = new FileReader();
         reader.onload = () => {
             const content = reader.result;
 
-            console.log("Conteúdo do arquivo:", content);
-
             try {
                 const parsedTransactions = [];
-                const transactionRegex = /<STMTTRN>[\s\S]*?<TRNTYPE>(.*?)<\/TRNTYPE>[\s\S]*?<DTPOSTED>([\d]+)<\/DTPOSTED>[\s\S]*?<TRNAMT>([-\d.]+)<\/TRNAMT>[\s\S]*?<NAME>(.*?)<\/NAME>[\s\S]*?<MEMO>(.*?)<\/MEMO>/g;
+                const transactionRegex = /<STMTTRN>[\s\S]*?<DTPOSTED>([\d]+)[\s\S]*?<TRNAMT>([-\d.]+)[\s\S]*?(?:<NAME>(.*?)<\/NAME>[\s\S]*?)?(?:<MEMO>(.*?)<\/MEMO>)?/g;
                 let match;
 
                 while ((match = transactionRegex.exec(content)) !== null) {
-                    const rawDate = match[2];
+                    const rawDate = match[1];
                     const formattedDate = formatDate(rawDate);
 
                     parsedTransactions.push({
-                        trnType: match[1],
                         date: formattedDate,
-                        amount: parseFloat(match[3]),
-                        name: match[4],
-                        memo: match[5],
+                        amount: parseFloat(match[2]),
+                        name: match[3] || "N/A", // Valor padrão se NAME não existir
+                        memo: match[4] || "N/A", // Valor padrão se MEMO não existir
                     });
                 }
 
@@ -58,33 +53,32 @@ const DataImport = () => {
         return `${day}/${month}/${year}`;
     };
 
+
     return (
         <div className="data-import">
             <h1>Importar OFX</h1>
-            <input type="file" accept=".ofx" onChange={handleFileUpload} />
+            <input type="file" accept=".ofx" onChange={handleFileUpload}/>
             <table className="data-table">
                 <thead>
                 <tr>
-                    <th>Tipo</th>
                     <th>Data</th>
-                    <th>Valor</th>
-                    <th>Nome</th>
                     <th>Descrição</th>
+                    <th>Nome</th>
+                    <th>Valor</th>
                 </tr>
                 </thead>
                 <tbody>
                 {transactions.length === 0 ? (
                     <tr>
-                        <td colSpan="5">Nenhuma transação encontrada.</td>
+                        <td colSpan="4">Nenhuma transação encontrada.</td>
                     </tr>
                 ) : (
                     transactions.map((transaction, index) => (
                         <tr key={index}>
-                            <td>{transaction.trnType}</td>
                             <td>{transaction.date}</td>
-                            <td>{transaction.amount.toFixed(2)}</td>
-                            <td>{transaction.name}</td>
                             <td>{transaction.memo}</td>
+                            <td>{transaction.name}</td>
+                            <td>{transaction.amount.toFixed(2)}</td>
                         </tr>
                     ))
                 )}

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -1,0 +1,146 @@
+import React, { useState } from "react";
+import "./index.css";
+
+const DataImport = () => {
+    const [transactions, setTransactions] = useState([]);
+
+    const handleFileUpload = (event) => {
+        const file = event.target.files[0];
+        if (!file) {
+            console.error("Nenhum arquivo selecionado.");
+            return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = () => {
+            const content = reader.result;
+
+            try {
+                const parsedTransactions = [];
+                const transactionRegex = /<STMTTRN>[\s\S]*?<DTPOSTED>([\d]+)[\s\S]*?<TRNAMT>([-\d.]+)[\s\S]*?<NAME>(.*?)<\/NAME>[\s\S]*?<MEMO>(.*?)<\/MEMO>/g;
+
+                let match;
+                while ((match = transactionRegex.exec(content)) !== null) {
+                    const rawDate = match[1];
+                    const formattedDate = formatDate(rawDate);
+
+                    parsedTransactions.push({
+                        date: formattedDate,
+                        amount: parseFloat(match[2]),
+                        name: match[3] ? match[3].trim() : "N/A",
+                        memo: match[4] ? match[4].trim() : "N/A",
+                        isFixed: false, // define as checkbox da coluna "Fixo" como falsa por padrao
+                    });
+                }
+
+                console.log("Transações extraídas:", parsedTransactions);
+                setTransactions(parsedTransactions);
+            } catch (error) {
+                console.error("Erro ao processar o arquivo:", error);
+            }
+        };
+
+        reader.onerror = () => {
+            console.error("Erro ao ler o arquivo.");
+        };
+
+        reader.readAsText(file);
+    };
+
+    const formatDate = (rawDate) => {
+        const year = rawDate.substring(0, 4);
+        const month = rawDate.substring(4, 6);
+        const day = rawDate.substring(6, 8);
+        return `${day}/${month}/${year}`;
+    };
+
+    const exportToCSV = () => {
+        if (transactions.length === 0) {
+            alert("Nenhuma transação para exportar.");
+            return;
+        }
+
+        const headers = ["Descrição", "Valor (R$)", "Data", "Nome", "Fixo"];
+        const rows = transactions.map((transaction) => [
+            transaction.memo,
+            transaction.amount.toFixed(2),
+            transaction.date,
+            transaction.name,
+            transaction.isFixed ? "Sim" : "Não", // adiciona a coluna fixo ao csv
+        ]);
+
+        const csvContent = [headers, ...rows]
+            .map((row) => row.join(","))
+            .join("\n");
+
+        const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+        const url = URL.createObjectURL(blob);
+
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = "transacoes.csv";
+        link.click();
+
+        URL.revokeObjectURL(url);
+    };
+
+    // alterna o estado da checkbox "Fixo"
+    const handleCheckboxChange = (index) => {
+        const newTransactions = [...transactions];
+        newTransactions[index].isFixed = !newTransactions[index].isFixed;
+        setTransactions(newTransactions);
+    };
+
+    return (
+        <div className="data-import">
+            <div className="titulo-extrato">Importar Extrato Bancário</div>
+            <div className="botoes">
+                <div className="upload-arquivo">
+                    <label className="input-ofx" for="file-upload">SELECIONE UM ARQUIVO</label>
+                    <input id="file-upload" type="file" accept=".ofx" onChange={handleFileUpload} />
+                </div>
+                {transactions.length > 0 && (
+                    <button className="export-button" onClick={exportToCSV}>
+                        Exportar para CSV
+                    </button>
+                )}
+            </div>
+            <table className="data-table">
+                <thead>
+                <tr>
+                    <th>Descrição</th>
+                    <th>Valor (R$)</th>
+                    <th>Data</th>
+                    <th>Nome</th>
+                    <th>Fixo</th>
+                </tr>
+                </thead>
+                <tbody>
+                {transactions.length === 0 ? (
+                    <tr>
+                        <td colSpan="5">Nenhuma transação encontrada.</td>
+                    </tr>
+                ) : (
+                    transactions.map((transaction, index) => (
+                        <tr key={index}>
+                            <td>{transaction.memo}</td>
+                            <td>{transaction.amount.toFixed(2)}</td>
+                            <td>{transaction.date}</td>
+                            <td>{transaction.name}</td>
+                            <td>
+                                <input
+                                    type="checkbox"
+                                    checked={transaction.isFixed}
+                                    onChange={() => handleCheckboxChange(index)} // Alterna o valor da checkbox
+                                />
+                            </td>
+                        </tr>
+                    ))
+                )}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default DataImport;

--- a/src/Pages/Protected/DataImport/index.jsx
+++ b/src/Pages/Protected/DataImport/index.jsx
@@ -112,7 +112,7 @@ const DataImport = () => {
     const handleCheckboxChange = (index) => {
         const newTransactions = [...transactions];
         newTransactions[index].isFixed = !newTransactions[index].isFixed;
-        newTransactions[index].flagUpdated = !newTransactions[index].flagUpdated;
+        newTransactions[index].flagUpdated = true;
         setTransactions(newTransactions);
     };
 

--- a/src/Pages/Protected/DataImport/index.test.jsx
+++ b/src/Pages/Protected/DataImport/index.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { APIBank } from "../../../Services/BaseService";
+import {
+  createFinancialMovements,
+  updateFinancialMovementsById,
+} from "../../../Services/FinancialMovementsService";
+import DataImport from "./index";
+import "@testing-library/jest-dom";
+
+vi.mock("../../../Services/BaseService", () => ({
+  APIBank: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("../../../Services/FinancialMovementsService", () => ({
+  createFinancialMovements: vi.fn(),
+  updateFinancialMovementsById: vi.fn(),
+}));
+
+describe("DataImport Component", () => {
+  beforeEach(() => {
+    localStorage.setItem("@App:user", JSON.stringify({ token: "mock-token" }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks(); // Limpa todos os mocks após cada teste
+    localStorage.clear(); // Limpa o localStorage após cada teste
+  });
+
+  it("renders the component correctly", () => {
+    render(<DataImport />);
+
+    // Verifica se os elementos estão sendo renderizados corretamente
+    expect(screen.getByText("Importar Extrato Bancário")).toBeInTheDocument();
+    expect(screen.getByText("SELECIONE UM ARQUIVO")).toBeInTheDocument();
+    expect(screen.getByText("SALVAR")).toBeInTheDocument();
+  });
+
+});

--- a/src/Pages/Protected/Finance/FinanceHubPage/index.jsx
+++ b/src/Pages/Protected/Finance/FinanceHubPage/index.jsx
@@ -26,6 +26,10 @@ export default function Finance() {
     navigate("/movimentacoes/relatorio");
   };
 
+  const handleImportarExtrato = () => {
+    navigate("/dataimport");
+  };
+
   return (
     user && (
       <section className="containerFinance">
@@ -69,6 +73,15 @@ export default function Finance() {
               <SecondaryButton
                 text="Gerar relatório"
                 onClick={handleGeradorRelatorio}
+              />
+            )}
+            {(checkAction("movimentacao_financeira_criar") ||
+              checkAction("movimentacao_financeira_editar") ||
+              checkAction("movimentacao_financeira_deletar") ||
+              checkAction("movimentacao_financeira_visualizar")) && (
+              <SecondaryButton
+                text="Extrato Bancário"
+                onClick={handleImportarExtrato}
               />
             )}
           </div>

--- a/src/Routes/protectedRoutes.jsx
+++ b/src/Routes/protectedRoutes.jsx
@@ -37,6 +37,8 @@ import GenerateFinancialReport from "../Pages/Protected/FinancialMovements/Gener
 import PermissionCRUD from "../Pages/Protected/Permissions/permissionsHandler.jsx";
 import { checkAction } from "../Utils/permission.jsx";
 
+import DataImport from "../Pages/Protected/DataImport/index.jsx";
+
 const ProtectedRoutes = () => {
   return (
     <Routes>
@@ -336,6 +338,16 @@ const ProtectedRoutes = () => {
             actions={["read", "create", "update"]}
           />
         }
+      />
+      <Route
+          path="/dataimport"
+          element={
+              <PermissionProtect
+                  element={<DataImport />}
+                  moduleName="finance"
+                  actions={["read", "create"]}
+              />
+          }
       />
     </Routes>
   );

--- a/src/Routes/protectedRoutes.jsx
+++ b/src/Routes/protectedRoutes.jsx
@@ -35,6 +35,7 @@ import ContributionHistoric from "../Pages/Protected/FinancialMovements/Contribu
 import Unauthorized from "../Pages/Protected/Unauthorized";
 import GenerateFinancialReport from "../Pages/Protected/FinancialMovements/GenerateFinancialReport";
 import PermissionCRUD from "../Pages/Protected/Permissions/permissionsHandler.jsx";
+import DataImport from "../Pages/Protected/DataImport/index.jsx";
 
 const ProtectedRoutes = () => {
   return (
@@ -333,6 +334,16 @@ const ProtectedRoutes = () => {
             actions={["read", "create", "update"]}
           />
         }
+      />
+      <Route
+          path="/dataimport"
+          element={
+              <PermissionProtect
+                  element={<CarteirinhaPage />}
+                  moduleName="finance"
+                  actions={["read", "create"]}
+              />
+          }
       />
     </Routes>
   );

--- a/src/Routes/publicRoutes.jsx
+++ b/src/Routes/publicRoutes.jsx
@@ -6,6 +6,7 @@ import ChangePasswordPage from "../Pages/Public/ChangePasswordPage";
 import LoginNovo from "../Pages/Public/LoginNovo";
 import VerifyMemberForm from "../Pages/Public/VerifyMember/VerifyMemberForm";
 import VerifyMemberActiveStatus from "../Pages/Public/VerifyMember/VerifyMemberActiveStatus";
+import DataImport from "../Pages/Protected/DataImport/index.jsx";
 
 const PublicRoutes = () => {
   return (
@@ -15,6 +16,7 @@ const PublicRoutes = () => {
       <Route path="/recuperar-senha" element={<PasswordRecovery />} />
       <Route path="/trocar-senha/:token" element={<ChangePasswordPage />} />
       <Route path="/verificar-membro" element={<VerifyMemberForm />} />
+      <Route path="/importar-dados" element={<DataImport />} />
       <Route
         path="/verificar-membro/ativo"
         element={<VerifyMemberActiveStatus />}


### PR DESCRIPTION
Os critérios de aceitação que foram feitos são:
A página deve listar todas as movimentações que estão com o tipo "Documento" em branco
Ter opção de editar a descrição
Ter opção de editar o tipo de transação
Ter opção de marcar como gasto recorrente "Fixo"
Link para US11->https://app.zenhub.com/workspaces/20242-sentinela-671a73b04c2c44000f895e1e/issues/gh/fga-eps-mds/2024.2-sentinela-doc/110
